### PR TITLE
DataSourceAutoConfigurationを除外する

### DIFF
--- a/src/main/java/com/example/game_application_server/GameApplicationServerApplication.java
+++ b/src/main/java/com/example/game_application_server/GameApplicationServerApplication.java
@@ -2,8 +2,9 @@ package com.example.game_application_server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = {DataSourceAutoConfiguration.class })
 public class GameApplicationServerApplication {
 
 	public static void main(String[] args) {


### PR DESCRIPTION
### 元Issue
- https://github.com/yoyo1025/game-application-server/issues/1

### 実施したこと
`@SpringBootApplication(exclude = {DataSourceAutoConfiguration.class })`で`DataSourceAutoConfiguration`を除外した

### 修正後の様子
- ログ
![game-application-server – GameApplicationServerApplication java 2024_12_06 23_26_58](https://github.com/user-attachments/assets/5c7cee28-4b66-457f-91ba-990144f81422)
```
2024-12-06T23:36:21.449+09:00  INFO 30520 --- [game-application-server] [  restartedMain] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat initialized with port 8080 (http)
2024-12-06T23:36:21.466+09:00  INFO 30520 --- [game-application-server] [  restartedMain] o.apache.catalina.core.StandardService   : Starting service [Tomcat]
```
より、locahost:8080で起動していることが分かる
