### PR TITLE
Eventクラス実装・テスト

### DIFF
--- a/src/main/java/com/example/game_application_server/domain/entity/Event.java
+++ b/src/main/java/com/example/game_application_server/domain/entity/Event.java
@@ -1,4 +1,141 @@
 package com.example.game_application_server.domain.entity;
 
+import java.util.*;
+
 public class Event {
+    public EventKind kind;
+    public Dice dice;
+
+    // デフォルトコンストラクタ
+    public Event() {
+        this.kind = EventKind.ROLL_AGAIN; // デフォルト値を設定
+    }
+
+    // 引数付きコンストラクタ
+    public Event(EventKind kind) {
+        this.kind = kind;
+    }
+
+    // Getter
+    public EventKind getKind() {
+        return kind;
+    }
+
+    // Setter
+    public void setKind(EventKind kind) {
+        this.kind = kind;
+    }
+
+    /**
+     * ROLL_AGAINイベントの場合は移動可能なPositionリストを返す。
+     * 他のイベント（SKIP_TURN、WARP）の場合は値の変更処理を行い、voidを返す。
+     *
+     * @param playerPositionMap 全プレイヤーの位置を管理するマップ
+     * @param players 全プレイヤーのリスト
+     * @param eventPlayerId イベントを発生させたプレイヤーID
+     * @param targetPlayerId SKIP_TURNやWARPでイベントの標的になるプレイヤーID
+     * @return ROLL_AGAINの場合は移動可能なPositionリスト、それ以外はvoid
+     */
+    public List<Position> executeEvent(Map<Player, Position> playerPositionMap, List<Player> players, int eventPlayerId, int targetPlayerId) {
+        // Idを0ベースに変換する
+        int eventPlayerIndex = eventPlayerId - 1;
+        int targetPlayerIndex = targetPlayerId - 1;
+
+        if (this.kind == EventKind.ROLL_AGAIN) {
+            return executeRollAgain(playerPositionMap, players, eventPlayerIndex);
+        }
+
+        // ROLL_AGAIN以外は値の変更処理
+        switch (this.kind) {
+            case SKIP_TURN -> executeSkipTurn(players, targetPlayerIndex);
+            case WARP -> executeWarp(playerPositionMap, players, eventPlayerIndex, targetPlayerIndex);
+            default -> throw new IllegalArgumentException("Unknown EventKind: " + this.kind);
+        }
+
+        // SKIP_TURN, WARPの場合はvoidとして終了
+        return Collections.emptyList();
+    }
+
+    public List<Position> executeRollAgain(Map<Player, Position> playerPositionMap, List<Player> players, int eventPlayerIndex) {
+        int diceResult = dice.roll();
+
+        Player eventPlayer = players.get(eventPlayerIndex);
+        Position currentPosition = playerPositionMap.get(eventPlayer);
+        if (currentPosition == null) {
+            throw new IllegalArgumentException("Position not found for player with ID: " + (eventPlayerIndex + 1));
+        }
+
+        // Setを用いることで座標の重複を排除する
+        Set<Position> possiblePositions = new HashSet<>();
+        List<Position> occupiedPositions = new ArrayList<>(playerPositionMap.values());
+        int fieldSize = 8;
+
+        for (int dx = 0; dx <= diceResult; dx++) {
+            for (int dy = 0; dy <= diceResult - dx; dy++) {
+                // 現在位置は除外
+                if (dx == 0 && dy == 0) {
+                    continue;
+                }
+
+                int x = currentPosition.getX();
+                int y = currentPosition.getY();
+
+                // 第1象限 (x+dx, y+dy)
+                addPositionIfValid(possiblePositions, occupiedPositions, x + dx, y + dy, fieldSize);
+
+                // dx,dyが0でない場合のみ対称位置を計算
+                // 第2象限 (x-dx, y+dy)
+                if (dx != 0) {
+                    addPositionIfValid(possiblePositions, occupiedPositions, x - dx, y + dy, fieldSize);
+                }
+                // 第3象限 (x-dx, y-dy)
+                if (dx != 0 && dy != 0) {
+                    addPositionIfValid(possiblePositions, occupiedPositions, x - dx, y - dy, fieldSize);
+                }
+                // 第4象限 (x+dx, y-dy)
+                if (dy != 0) {
+                    addPositionIfValid(possiblePositions, occupiedPositions, x + dx, y - dy, fieldSize);
+                }
+            }
+        }
+
+        // SetをListに変換して返す
+        return new ArrayList<>(possiblePositions);
+    }
+
+    public void addPositionIfValid(Set<Position> possiblePositions, List<Position> occupiedPositions, int x, int y, int fieldSize) {
+        if (x >= 0 && x < fieldSize && y >= 0 && y < fieldSize) {
+            Position newPosition = new Position(x, y);
+            if (!occupiedPositions.contains(newPosition)) {
+                possiblePositions.add(newPosition);
+            }
+        }
+    }
+
+    public void executeSkipTurn(List<Player> players, int targetPlayerIndex) {
+        players.get(targetPlayerIndex).isOnBreak = true;
+    }
+
+    public void executeWarp(Map<Player, Position> playerPositionMap, List<Player> players, int eventPlayerIndex , int targetPlayerIndex) {
+        // イベントプレイヤーとターゲットプレイヤーの位置を取得
+        Player eventPlayer = players.get(eventPlayerIndex);
+        Player targetPlayer = players.get(targetPlayerIndex);
+
+        // イベントプレイヤーとターゲットプレイヤーの現在地を取得
+        Position eventPlayerPosition = playerPositionMap.get(eventPlayer);
+        Position targetPlayerPosition = playerPositionMap.get(targetPlayer);
+
+        if (eventPlayerPosition == null || targetPlayerPosition == null) {
+            throw new IllegalArgumentException("Position not found for one or both players.");
+        }
+
+        // 位置を入れ替える
+        playerPositionMap.put(eventPlayer, targetPlayerPosition);
+        playerPositionMap.put(targetPlayer, eventPlayerPosition);
+    }
+
+    @Override
+    public String toString() {
+        return "Event{kind=" + kind + "}";
+    }
 }

--- a/src/main/java/com/example/game_application_server/domain/entity/Position.java
+++ b/src/main/java/com/example/game_application_server/domain/entity/Position.java
@@ -1,5 +1,7 @@
 package com.example.game_application_server.domain.entity;
 
+import java.util.Objects;
+
 public class Position {
     private int x;
     private int y;
@@ -33,4 +35,18 @@ public class Position {
     public String toString() {
         return "Position{" + "x=" + x + ", y=" + y + '}';
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+        Position position = (Position) obj;
+        return x == position.x && y == position.y;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(x, y);
+    }
+
 }

--- a/src/test/java/com/example/game_application_server/domain/entity/EventTest.java
+++ b/src/test/java/com/example/game_application_server/domain/entity/EventTest.java
@@ -1,0 +1,2 @@
+package com.example.game_application_server.domain.entity;public class EventTest {
+}

--- a/src/test/java/com/example/game_application_server/domain/entity/EventTest.java
+++ b/src/test/java/com/example/game_application_server/domain/entity/EventTest.java
@@ -1,2 +1,141 @@
-package com.example.game_application_server.domain.entity;public class EventTest {
+package com.example.game_application_server.domain.entity;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+class EventTest {
+
+    private Dice mockDice; // サイコロのモックオブジェクト
+    private Event event;   // テスト対象の Event オブジェクト
+
+    private Player player1; // プレイヤー1
+    private Player player2; // プレイヤー2
+
+    private Map<Player, Position> playerPositionMap; // プレイヤーとその位置を管理するマップ
+    private List<Player> players; // プレイヤーのリスト
+
+    @BeforeEach
+    void setUp() {
+        // サイコロのモックを作成
+        mockDice = Mockito.mock(Dice.class);
+        event = new Event(EventKind.ROLL_AGAIN);
+        event.dice = mockDice;
+
+        // プレイヤーを初期化
+        player1 = new Player(1, "Alice", true, false);
+        player2 = new Player(2, "Bob", true, false);
+
+        // プレイヤーリストを作成
+        players = Arrays.asList(player1, player2);
+
+        // プレイヤーの位置を設定
+        playerPositionMap = new HashMap<>();
+        playerPositionMap.put(player1, new Position(3, 3));
+        playerPositionMap.put(player2, new Position(4, 3));
+    }
+
+    @Test
+    void testExecuteRollAgain() {
+        // サイコロの目を3に固定
+        when(mockDice.roll()).thenReturn(3);
+
+        // Player1がROLL_AGAINイベントを実行
+        List<Position> positions = event.executeRollAgain(playerPositionMap, players, 0);
+
+        // 結果がnullでないことを確認
+        assertNotNull(positions);
+
+        // 現在地 (3, 3) と他プレイヤーの位置 (4, 3) が除外されていることを確認
+        assertFalse(positions.contains(new Position(3, 3))); // 現在地
+        assertFalse(positions.contains(new Position(4, 3))); // 他プレイヤーの位置
+
+        // サイコロの目を基に移動可能な座標が正しく含まれていることを確認
+        assertTrue(positions.contains(new Position(3, 6))); // 上方向に3マス
+        assertTrue(positions.contains(new Position(6, 3))); // 右方向に3マス
+    }
+
+    @Test
+    void testExecuteRollAgain_NoPosition() {
+        // player1の位置情報を削除
+        playerPositionMap.remove(player1);
+
+        // サイコロの目を2に固定
+        when(mockDice.roll()).thenReturn(2);
+
+        // プレイヤーの位置が存在しない場合に例外がスローされることを確認
+        assertThrows(IllegalArgumentException.class, () -> event.executeRollAgain(playerPositionMap, players, 0));
+    }
+
+    @Test
+    void testExecuteSkipTurn() {
+        // SKIP_TURN イベントを設定
+        event.setKind(EventKind.SKIP_TURN);
+
+        // Player2を休憩状態に設定
+        event.executeSkipTurn(players, 1);
+
+        // Player2が休憩状態になっていることを確認
+        assertTrue(player2.isOnBreak);
+    }
+
+    @Test
+    void testExecuteWarp() {
+        // WARP イベントを設定
+        event.setKind(EventKind.WARP);
+
+        // プレイヤー1 (3, 3) とプレイヤー2 (4, 3) の位置を入れ替え
+        event.executeWarp(playerPositionMap, players, 0, 1);
+
+        // 位置が正しく入れ替わっていることを確認
+        assertEquals(new Position(4, 3), playerPositionMap.get(player1));
+        assertEquals(new Position(3, 3), playerPositionMap.get(player2));
+    }
+
+    @Test
+    void testExecuteEvent() {
+        // ROLL_AGAIN イベントの動作確認
+        when(mockDice.roll()).thenReturn(3);
+        event.setKind(EventKind.ROLL_AGAIN);
+
+        List<Position> positions = event.executeEvent(playerPositionMap, players, 1, 2);
+        // 結果がnullでないことを確認
+        assertNotNull(positions);
+
+        // 現在地 (3, 3) と他プレイヤーの位置 (4, 3) が除外されていることを確認
+        assertFalse(positions.contains(new Position(3, 3))); // 現在地
+        assertFalse(positions.contains(new Position(4, 3))); // 他プレイヤーの位置
+
+        // サイコロの目を基に移動可能な座標が正しく含まれていることを確認
+        assertTrue(positions.contains(new Position(3, 6))); // 上方向に3マス
+        assertTrue(positions.contains(new Position(6, 3))); // 右方向に3マス
+
+        // SKIP_TURN イベントの動作確認
+        event.setKind(EventKind.SKIP_TURN);
+        event.executeEvent(playerPositionMap, players, 1, 2);
+        assertTrue(player2.isOnBreak);
+
+        // WARP イベントの動作確認
+        event.setKind(EventKind.WARP);
+        event.executeEvent(playerPositionMap, players, 1, 2);
+        assertEquals(new Position(4, 3), playerPositionMap.get(player1));
+    }
+
+    @Test
+    void testExecuteEvent_UnknownKind() {
+        // イベント種別が無効な場合に例外がスローされることを確認
+        event.setKind(null);
+        assertThrows(NullPointerException.class, () -> event.executeEvent(playerPositionMap, players, 1, 2));
+    }
+
+    @Test
+    void testToString() {
+        // toString メソッドの結果が期待通りであることを確認
+        assertEquals("Event{kind=ROLL_AGAIN}", event.toString());
+    }
 }


### PR DESCRIPTION
## もとIssue
- https://github.com/yoyo1025/game-application-server/issues/14
## テスト内容
### 1. `testExecuteRollAgain`
- **目的**: `ROLL_AGAIN`イベント実行時の移動可能な座標リストが正しく計算されるかを確認。
- **内容**:
  - サイコロの目を固定（例: `3`）に設定。
  - 現在地や他プレイヤーの位置が除外されていることを確認。
  - サイコロの目を基に計算された座標が正しく含まれていることを確認。
- **確認項目**:
  - [x] リストが`null`でないこと。
  - [x] 現在地（`(3, 3)`）が除外されていること。
  - [x] 他プレイヤーの位置（`(4, 3)`）が除外されていること。
  - [x] 有効な移動先（例: `(3, 6)`、`(6, 3)`）が含まれていること。
- **移動可能な座標**:
[Position{x=3, y=2}, Position{x=2, y=1}, Position{x=5, y=4}, Position{x=4, y=4}, Position{x=2, y=2}, Position{x=3, y=4}, Position{x=2, y=3}, Position{x=4, y=5}, Position{x=1, y=2}, Position{x=3, y=5}, Position{x=2, y=4}, Position{x=1, y=3}, Position{x=3, y=6}, Position{x=2, y=5}, Position{x=1, y=4}, Position{x=0, y=3}, Position{x=3, y=0}, Position{x=4, y=1}, Position{x=5, y=2}, Position{x=6, y=3}, Position{x=3, y=1}, Position{x=4, y=2}, Position{x=5, y=3}]

---

### 2. `testExecuteRollAgain_NoPosition`
- **目的**: プレイヤーの位置情報が存在しない場合に適切な例外がスローされることを確認。
- **内容**:
  - `playerPositionMap`からプレイヤーの位置を削除。
  - `ROLL_AGAIN`イベントを実行。
- **確認項目**:
  - `[ ] IllegalArgumentException`がスローされること。

---

### 3. `testExecuteSkipTurn`
- **目的**: `SKIP_TURN`イベントが正しく対象プレイヤーの休憩状態を更新するかを確認。
- **内容**:
  - 対象プレイヤーの`isOnBreak`フラグを`true`に更新。
- **確認項目**:
  - [x] 対象プレイヤーの`isOnBreak`フラグが`true`であること。

---

### 4. `testExecuteWarp`
- **目的**: `WARP`イベントがイベントプレイヤーと対象プレイヤーの位置を正しく交換するかを確認。
- **内容**:
  - プレイヤー1（`(3, 3)`）とプレイヤー2（`(4, 3)`）の位置を交換。
- **確認項目**:
  - [x] プレイヤー1の位置が`(4, 3)`になっていること。
  - [x] プレイヤー2の位置が`(3, 3)`になっていること。

---

### 5. `testExecuteEvent`
- **目的**: `executeEvent`メソッドの統合的な動作確認。
- **内容**:
  - **`ROLL_AGAIN`**:
    - サイコロの目を固定（例: `3`）。
    - 移動可能な座標リストが正しく計算されるかを確認。
  - **`SKIP_TURN`**:
    - 対象プレイヤーの`isOnBreak`フラグを`true`に更新。
  - **`WARP`**:
    - プレイヤー1とプレイヤー2の位置を交換。
- **確認項目**:
  - [x] `ROLL_AGAIN`: 移動可能な座標が正しく計算されていること。
  - [x] `SKIP_TURN`: 対象プレイヤーの休憩状態が更新されていること。
  - [x] `WARP`: プレイヤーの位置が正しく交換されていること。

---

### 6. `testExecuteEvent_UnknownKind`
- **目的**: イベント種別が無効（例: `null`）の場合に例外がスローされることを確認。
- **内容**:
  - イベント種別を`null`に設定し、イベントを実行。
- **確認項目**:
  - [x] `NullPointerException`がスローされること。

---

### 7. `testToString`
- **目的**: `toString`メソッドが正しい文字列を返すことを確認。
- **内容**:
  - イベント種別が`ROLL_AGAIN`のとき、`"Event{kind=ROLL_AGAIN}"`という文字列を返すか確認。
- **確認項目**:
  - [x] 期待される文字列が正しく出力されること。

---

### 補足
- サイコロ（`Dice`）の目はモック化して固定値を設定。
- テストケースでは正常系と異常系の両方を網羅。
- プレイヤー情報や位置情報を用いた、実用的な動作を確認済み。