### PR TITLE
マスを移動する処理の実装

### DIFF
--- a/src/main/java/com/example/game_application_server/application/MoveUsecase.java
+++ b/src/main/java/com/example/game_application_server/application/MoveUsecase.java
@@ -1,4 +1,33 @@
 package com.example.game_application_server.application;
 
+import com.example.game_application_server.domain.entity.Player;
+import com.example.game_application_server.domain.entity.Position;
+import com.example.game_application_server.domain.service.GameState;
+import org.springframework.stereotype.Service;
+
+@Service
 public class MoveUsecase {
+    private final GameStateManager gameStateManager;
+
+    public MoveUsecase(GameStateManager gameStateManager) {
+        this.gameStateManager = gameStateManager;
+    }
+
+    public GameState excute(Position targetPosition, int userId) {
+        GameState gameState = gameStateManager.getGameState();
+
+        Player currentPlayer = gameState.players.get(gameState.turn.getCurrentPlayerIndex() - 1);
+        if (currentPlayer.getUserId() != userId) {
+            throw new IllegalStateException("あなたのターンではありません");
+        }
+
+        // プレイヤーの位置を更新
+        gameState.setPlayerPosition(currentPlayer, targetPosition);
+
+        gameState.turn.nextPlayerIndex();
+
+        return gameState;
+    }
 }
+
+

--- a/src/main/java/com/example/game_application_server/domain/entity/Turn.java
+++ b/src/main/java/com/example/game_application_server/domain/entity/Turn.java
@@ -53,6 +53,7 @@ public class Turn {
         this.currentPlayerIndex++;
         if (this.currentPlayerIndex > 4) {
             this.currentPlayerIndex = 1;
+            this.current_turn++;
         }
     }
 

--- a/src/main/java/com/example/game_application_server/dto/MoveRequestDTO.java
+++ b/src/main/java/com/example/game_application_server/dto/MoveRequestDTO.java
@@ -1,0 +1,34 @@
+package com.example.game_application_server.dto;
+
+import com.example.game_application_server.domain.entity.Position;
+
+public class MoveRequestDTO {
+    public int userId;
+    public int currentPlayerIndex;
+    public Position targetPosition;
+
+    // GetterとSetter
+    public int getUserId() {
+        return userId;
+    }
+
+    public void setUserId(int userId) {
+        this.userId = userId;
+    }
+
+    public int getCurrentPlayerIndex() {
+        return currentPlayerIndex;
+    }
+
+    public void setCurrentPlayerIndex(int currentPlayerIndex) {
+        this.currentPlayerIndex = currentPlayerIndex;
+    }
+
+    public Position getTargetPosition() {
+        return targetPosition;
+    }
+
+    public void setTargetPosition(Position targetPosition) {
+        this.targetPosition = targetPosition;
+    }
+}


### PR DESCRIPTION
## 概要
本PRでは、プレイヤーの移動を実行するユースケースを実装しました。この機能は、プレイヤーがターン内で位置を更新し、次のプレイヤーにターンを移すロジックを含みます。

## もとIssue
- https://github.com/yoyo1025/game-application-server/issues/47

## 主な変更点

### 1. **MoveUsecase クラスの実装**
`MoveUsecase`は以下の責務を持つサービスクラスとして実装されています：
- 現在のゲーム状態を取得する。
- リクエストされたプレイヤーが現在のターンか確認し、不正な操作を防ぐ。
- プレイヤーの位置を更新する。
- ターンを次のプレイヤーに進める。

#### 主なメソッド
- `excute(Position targetPosition, int userId)`
  - 指定された位置とユーザーIDを基にゲーム状態を更新します。
  - ユーザーが現在のターンかどうかを確認し、不正操作時には例外をスローします。

---

### 2. **MoveRequestDTO クラスの作成**
移動リクエスト用のDTO(Data Transfer Object)として以下のプロパティを持ちます：
- `userId`: ユーザーID。
- `currentPlayerIndex`: 現在のプレイヤーのインデックス。
- `targetPosition`: 移動先の位置を保持する`Position`オブジェクト。

#### 主な機能
- Getter/Setter メソッドを提供して、リクエストボディとのマッピングを容易にします。

---

### 3. **Controller に移動APIを追加**
移動を実行するエンドポイントを追加しました。

#### エンドポイント
- `POST /move`
  - リクエストボディを`MoveRequestDTO`として受け取り、以下を実行します：
    1. `MoveUsecase`を用いてゲーム状態を更新。
    2. 更新後のゲーム状態をWebSocketで通知。
    3. HTTPレスポンスとしてゲーム状態を返却。

#### エラー処理
- 現在のターンではないユーザーが操作を試みた場合、`403 Forbidden`ステータスとエラーメッセージを返却します。

---

### 4. **WebSocket通知の追加**
移動後のゲーム状態を`/topic/newPosition`に配信し、リアルタイム通知を実現します。

---

## 実装の動作確認
- プレイヤーがターン中に正しく移動できることを確認。
- ターン外のプレイヤーが移動を試みた場合にエラーが発生することを確認。
- WebSocketを通じてクライアントに正しく更新が通知されることを確認。

以上の内容により、プレイヤーの移動ロジックとリアルタイム通知機能が実装されました。
