### PR TITLE
鬼が村人を捕まえる処理の実装

### DIFF
--- a/src/main/java/com/example/game_application_server/application/MoveUsecase.java
+++ b/src/main/java/com/example/game_application_server/application/MoveUsecase.java
@@ -1,9 +1,14 @@
 package com.example.game_application_server.application;
 
+import com.example.game_application_server.domain.entity.Demon;
 import com.example.game_application_server.domain.entity.Player;
 import com.example.game_application_server.domain.entity.Position;
+import com.example.game_application_server.domain.entity.Villager;
 import com.example.game_application_server.domain.service.GameState;
 import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.Optional;
 
 @Service
 public class MoveUsecase {
@@ -17,17 +22,55 @@ public class MoveUsecase {
         GameState gameState = gameStateManager.getGameState();
 
         Player currentPlayer = gameState.players.get(gameState.turn.getCurrentPlayerIndex() - 1);
+
+        // ターンチェック
         if (currentPlayer.getUserId() != userId) {
             throw new IllegalStateException("あなたのターンではありません");
         }
 
+        // 位置が他のプレイヤーと重複しているかを確認
+        Optional<Map.Entry<Player, Position>> capturedEntry = gameState.playerPositions.entrySet().stream()
+                .filter(entry -> entry.getValue().equals(targetPosition))
+                .findFirst();
+
+        capturedEntry.ifPresent(entry -> {
+            Player capturedPlayer = entry.getKey();
+            System.out.println("Captured player: " + capturedPlayer.getName());
+
+            Villager villager = (Villager) capturedPlayer;
+            Demon demon = (Demon) currentPlayer;
+            demon.capture(villager);
+            System.out.println("Villager captured by Demon: " + villager.getName());
+        });
+
         // プレイヤーの位置を更新
         gameState.setPlayerPosition(currentPlayer, targetPosition);
 
+        // 次のプレイヤーのターンに移行
         gameState.turn.nextPlayerIndex();
 
+        // ---- ここからが「死んだプレイヤーのターンをスキップ」する処理 ----
+        Player nextPlayer = gameState.players.get(gameState.turn.getCurrentPlayerIndex() - 1);
+
+        // 全員が死んでいるケースなどを避けるため、最大人数分だけループする
+        int skipCount = 0;
+        int maxPlayers = gameState.players.size();
+
+        // 全員が死んでいると無限ループになる可能性があるため、回数制限を設ける
+        while (skipCount < maxPlayers) {
+            // 次のプレイヤーが村人 かつ その村人が死んでいる場合はそのプレイヤーのターンをスキップ
+            if (nextPlayer instanceof Villager && !((Villager) nextPlayer).isAlive()) {
+                gameState.turn.nextPlayerIndex();
+                nextPlayer = gameState.players.get(gameState.turn.getCurrentPlayerIndex() - 1);
+                skipCount++;
+            } else {
+                // 生きている村人 or 鬼ならターンを確定
+                break;
+            }
+        }
         return gameState;
     }
+
 }
 
 


### PR DESCRIPTION
## 実装概要
1. **プレイヤーの位置が他のプレイヤーと重複した場合の処理**
   - 鬼（Demon）が村人（Villager）を捕まえる機能を追加。
   - 捕まえられた村人の`isAlive`フラグが`false`に設定される。

2. **死んでいるプレイヤーのターンをスキップする処理**
   - ターンが死んでいる村人に回った場合、自動的に次のプレイヤーに進む。

---

## 実装内容

### 1. 鬼が村人を捕まえる処理の追加

以下のロジックを `MoveUsecase` クラスに追加した。移動先の位置がすでに他のプレイヤーと重複している場合、そのプレイヤーを捕まえる。

```java
// 位置が他のプレイヤーと重複しているかを確認
Optional<Map.Entry<Player, Position>> capturedEntry = gameState.playerPositions.entrySet().stream()
    .filter(entry -> entry.getValue().equals(targetPosition))
    .findFirst();

capturedEntry.ifPresent(entry -> {
    Player capturedPlayer = entry.getKey();
    System.out.println("Captured player: " + capturedPlayer.getName());

    // キャプチャ処理: 鬼が村人を捕まえる
    Villager villager = (Villager) capturedPlayer;
    Demon demon = (Demon) currentPlayer;
    demon.capture(villager); // villager.setAlive(false); が呼ばれる
    System.out.println("Villager captured by Demon: " + villager.getName());
});
```

### 2.プレイヤーの位置を更新する処理
捕まえた処理の後、現在のプレイヤーの位置を更新する。
```java
// プレイヤーの位置を更新
gameState.setPlayerPosition(currentPlayer, targetPosition);
```
### 3. 死んでいるプレイヤーのターンをスキップする処理
以下のロジックを追加し、ターンが死んでいるプレイヤーに回った場合、自動的に次のプレイヤーに進むようにした。
```java
// 次のプレイヤーのターンに移行
gameState.turn.nextPlayerIndex();

// 死んだプレイヤーのターンをスキップ
Player nextPlayer = gameState.players.get(gameState.turn.getCurrentPlayerIndex() - 1);
int skipCount = 0;
int maxPlayers = gameState.players.size();

while (skipCount < maxPlayers) {
    // 死んだ村人のターンはスキップ
    if (nextPlayer instanceof Villager && !((Villager) nextPlayer).isAlive()) {
        gameState.turn.nextPlayerIndex();
        nextPlayer = gameState.players.get(gameState.turn.getCurrentPlayerIndex() - 1);
        skipCount++;
    } else {
        break; // 生きている村人 or 鬼ならターン確定
    }
}
```