### PR TITLE
ロビーサーバーからの通信を許可&起動するポートを変更

### DIFF
--- a/src/main/java/com/example/game_application_server/presentation/GameController.java
+++ b/src/main/java/com/example/game_application_server/presentation/GameController.java
@@ -19,7 +19,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 @RestController
 @RequestMapping("/api")
-@CrossOrigin(origins = "http://localhost:3000")
+@CrossOrigin(origins = {"http://localhost:3000", "http://localhost:8080"})
 public class GameController {
 
     public final SimpMessagingTemplate messagingTemplate;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.application.name=game-application-server
+server.port=8000


### PR DESCRIPTION
## 実装内容
- `localhost:8080`からの通信を許可
- 起動するポートを`8080番`から`8000番`に変更